### PR TITLE
Create mconfig.h for fuzzing

### DIFF
--- a/src/tests/cptests/Makefile
+++ b/src/tests/cptests/Makefile
@@ -38,7 +38,13 @@ clean:
 fuzz_parent_test_objects = $(foreach obj,$(notdir $(parent_test_objects)),fuzz-$(obj))
 fuzz_objects = $(foreach obj,$(parent_objs),fuzz-$(obj))
 
-fuzz: prepare-incdir fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
+# Create mconfig.h for fuzzing. because fuzz target not runned by top level make; we need to create mconfig.h manually.
+gen-mconfig:
+	$(MAKE) -C ../../../ mconfig
+	$(MAKE) -C ../../../build/tools/
+	../../../build/tools/mconfig-gen | tee includes/mconfig.h
+
+fuzz: prepare-incdir gen-mconfig fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects)
 	clang++ -std=c++11 -g -O1 -Iincludes -I../../../dasynq/include -fsanitize=fuzzer,address,undefined,leak fuzz.cc $(fuzz_parent_test_objects) $(fuzz_objects) -o fuzz
 
 $(fuzz_parent_test_objects): fuzz-%.o: ../%.cc


### PR DESCRIPTION
because fuzz target not runned by top level make; we need to create mconfig.h manually.